### PR TITLE
Add TinyPilot's base style conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # style-guides
-Style guides for TinyPilot coding conventions
+
+This page defines TinyPilot's coding conventions for various programming languages.
+
+## General
+
+TinyPilot's style guides mostly inherit from other established style guides and make changes where we've felt the parent guide lacks specificity or makes a choice that's inappropriate for TinyPilot's work.
+
+## Python
+
+- Base Guide: [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
+
+## HTML/CSS
+
+- Base Guide: [Google HTML/CSS Style Guide](https://google.github.io/styleguide/htmlcssguide.html)
+
+## Shell
+
+- Base Guide: [Google Shell](https://google.github.io/styleguide/shellguide.html)
+
+## JavaScript
+
+TinyPilot doesn't have well-defined conventions for JavaScript. We are "loosely inspired" by [Google's JavaScript style guide](https://google.github.io/styleguide/jsguide.html), but don't observe it strictly.
+
+The convention is to try to be consistent with existing code in the TinyPilot repos.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This page defines TinyPilot's coding conventions for various programming languag
 
 ## General
 
-TinyPilot's style guides mostly inherit from other established style guides and make changes where we've felt the parent guide lacks specificity or makes a choice that's inappropriate for TinyPilot's work.
+TinyPilot's style guides mostly inherit from other established style guides and make changes where we've felt the parent guide lacks specificity or makes a choice that's poorly suited for TinyPilot's work.
 
 ## Python
 


### PR DESCRIPTION
This is adapted from the TinyPilot repo's CONTRIBUTING guide: https://github.com/tiny-pilot/tinypilot/blob/7329336557d36fde2e8d09adecdb0f062c1e30e1/CONTRIBUTING.md#code-style-conventions

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/style-guides/1"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>