### PR TITLE
Add TinyPilot-specific conventions for shell style

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ TinyPilot's style guides mostly inherit from other established style guides and 
 
 ### Shellcheck
 
-All repositories with
+All repositories with shell scripts should enable shellcheck to run automatically in CI. See [the `check_bash` job](https://github.com/tiny-pilot/tinypilot/blob/master/.circleci/config.yml) in tiny-pilot/tinypilot for an example.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ Variable names should be all uppercase.
 WELCOME_MESSAGE="Hello, world!"
 ```
 
+### Error messages
+
+* Print error messages to stderr.
+* Error messages don't have any prefixes like "ERROR:" or "WARNING:".
+* Use sentence casing to capitalize error messages.
+* Omit trailing punctuation on error messages.
+
+```bash
+echo 'Mount mode must be either FLASH or CDROM' >&2
+```
+
 ## JavaScript
 
 TinyPilot doesn't have well-defined conventions for JavaScript. We are "loosely inspired" by [Google's JavaScript style guide](https://google.github.io/styleguide/jsguide.html), but don't observe it strictly.

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ TinyPilot's style guides mostly inherit from other established style guides and 
 
 ### Shellcheck
 
-All repositories with shell scripts should enable shellcheck to run automatically in CI. See [the `check_bash` job](https://github.com/tiny-pilot/tinypilot/blob/master/.circleci/config.yml) in tiny-pilot/tinypilot for an example.
+All repositories with shell scripts should enable shellcheck to run automatically in CI. See [the `check_bash` job](https://github.com/tiny-pilot/tinypilot/blob/master/.circleci/config.yml) in `tiny-pilot/tinypilot` for an example.
 
 ### Options
 
 All bash scripts should default to these options unless there's a strong need to exclude any of them.
 
 ```bash
-# Exit build script on first failure.
+# Exit on first failure.
 set -e
 
 # Echo commands to stdout.
@@ -53,6 +53,12 @@ Variable names should be all uppercase.
 
 ```bash
 WELCOME_MESSAGE="Hello, world!"
+```
+
+```bash
+for URL in "${URLS[@]}"; do
+  wget "${URL}"
+done
 ```
 
 ### Error messages

--- a/README.md
+++ b/README.md
@@ -18,6 +18,43 @@ TinyPilot's style guides mostly inherit from other established style guides and 
 
 - Base Guide: [Google Shell](https://google.github.io/styleguide/shellguide.html)
 
+### Shellcheck
+
+All repositories with
+
+### Options
+
+All bash scripts should default to these options unless there's a strong need to exclude any of them.
+
+```bash
+# Exit build script on first failure.
+set -e
+
+# Echo commands to stdout.
+set -x
+
+# Exit on unset variable.
+set -u
+```
+
+### Comments
+
+Comments begin with a capital letter and end with trailing punctuation.
+
+```bash
+# Our contract with FooVendor requires us to wait five seconds before each
+# request.
+TIMEOUT_SECONDS=5
+```
+
+### Variable names
+
+Variable names should be all uppercase.
+
+```bash
+WELCOME_MESSAGE="Hello, world!"
+```
+
 ## JavaScript
 
 TinyPilot doesn't have well-defined conventions for JavaScript. We are "loosely inspired" by [Google's JavaScript style guide](https://google.github.io/styleguide/jsguide.html), but don't observe it strictly.


### PR DESCRIPTION

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/style-guides/2"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>