### PR TITLE
Add conventions for Github pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Can omit when trivial.
 
 Include "Fixes XX"
 
+The reader should understand everything in the PR description. If we're linking to external resources, quote the relevant parts (the external links could disappear). If we're linking to a bug, don't force the reader to read the full bug. Summarize what they need to know. Link to specific headers in external docs.
+
+Revise PR descriptions to match implementation.
+
 ## Python
 
 - Base Guide: [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This is a better PR description because it explains the "why" behind the change.
 
 #### Cross-referencing issues
 
-If the PR resolves a bug, include a line after the prose description that says `Fixes #XXX` where `XXX` is the number of the Github issue it resolves. The `Fixes #XXX` has special meaning within Github, as merging the PR will auto-close the associated issue.
+If the PR resolves a Github issue, make the first line of the description `Resolves #XXX`, where `XXX` is the number of the Github issue it resolves. The `Resolves #XXX` [has special meaning](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) within Github, as merging the PR will auto-close the associated issue.
 
 If the PR is related to an issue but doesn't fix it, add a line that says `Related #XXX` so that Github cross-references the PR from the associated bug.
 

--- a/README.md
+++ b/README.md
@@ -6,39 +6,67 @@ This page defines TinyPilot's coding conventions for various programming languag
 
 TinyPilot's style guides mostly inherit from other established style guides and make changes where we've felt the parent guide lacks specificity or makes a choice that's poorly suited for TinyPilot's work.
 
-## Pull requests
-
-Pull requests (PRs)
-
-Focus on the why rather than the how.
-
-Should introduce the reader to
-
-If there were implementation decisions, include them.
+## Github pull requests
 
 ### Titles
 
-* Aim for fewer than 80 characters
-  * This is a soft limit, but it's better to be succinct
-  * In some views (including on Github), exceeding 80 characters screws up the PR link
-* Use imperative mood ("Refactor input handling") rather than descriptive ("Refactors input handling")
-* Use sentence casing.
+The pull request (PR) title should summarize the change to make it easy for other developers to quickly scan through the change history for the repo or a file/folder.
+
+* Aim for fewer than 80 characters.
+  * This is a soft limit, but it's better to be succinct.
+  * In some views (including on Github), exceeding 80 characters screws up the PR link.
+* Use imperative mood ("Refactor input handling") rather than descriptive ("Refactors input handling").
+* Use sentence casing ("Refactor input handling" rather than "Refactor Input Handling").
 * Omit trailing punctuation.
 * Omit prefixes like "(chore)" or "(fix)".
+* Omit Markdown formatting.
+  * Github renders Markdown in PR titles, but not all git clients do.
 
 ### Descriptions
 
-Pull request descriptions
+The pull request description should introduce the reader to the change and provide them with the context they need to review the change. Write the pull request so that it makes sense to anyone on the team even if you have a particular reviewer in mind who has additional context. Other people might want to read the PR, and you might forget the context in the future if you look back on it.
 
-The PR description can introduce the reader . The PR description is a description of the *change* rather than the code. If there's context the reader needs to understand the code, the code itself should provide that context. After the code is merged, it should make sense to people who haven't read the pull request description.
+#### What to include
 
-Can omit when trivial.
+Link to external resources when appropriate, but the reader should be able to understand everything in the PR description without clicking external links. If you're linking to a bug, summarize the relevant details of the bug. If you're linking to external documentation, quote the relevant section and link back to the original (linking to the specific header if possible).
 
-Include "Fixes XX"
+If you made design choices in the PR, explain why you chose a particular implementation over other possible candidates.
 
-The reader should understand everything in the PR description. If we're linking to external resources, quote the relevant parts (the external links could disappear). If we're linking to a bug, don't force the reader to read the full bug. Summarize what they need to know. Link to specific headers in external docs.
+For very trivial PRs, the description is optional, but it's usually helpful to include a description.
 
-Revise PR descriptions to match implementation.
+#### Focus on the "why" rather than the "how"
+
+The PR description is a description of the *change* rather than the code. It should answer the question, "Why are we making this change right now?"
+
+If there's context the reader needs to understand the code, the code itself should provide that context either through naming or code comments. After the code is merged, the code needs to make sense to people who haven't read the pull request description.
+
+Example bad description:
+
+>**Move user.js**
+>
+>This change moves user.js to the `src/controllers/auth` directory.
+
+This is a poor description because it doesn't give the reader any information about the change beyond what they'd see in the diff.
+
+Example good description:
+
+>**Move user.js to src/controllers/auth**
+>
+>When we created `user.js`, most of its callers lived in `src/lib/user`.
+>
+>We did a lot of restructing as part of the 4.2.x release, so now all of user.js’s clients live in `src/controllers/auth`, so this change moves `user.js` closer to the majority of its clients.
+
+This is a better PR description because it explains the "why" behind the change. The reader has context to understand why this change is happening.
+
+#### Cross-referencing issues
+
+If the PR resolves a bug, include a line after the prose description that says `Fixes #XXX` where `XXX` is the number of the Github issue it resolves. Doing this lets Github auto-close the associated issue when we merge the PR.
+
+If the PR is related to an issue but doesn't fix it, add a line that says `Related #XXX` so that Github cross-references the PR from the associated bug.
+
+#### Revise to match design changes
+
+Sometimes the code review process causes changes in the code that make your original PR description obsolete. Remember to update your PR description to match the state of your code.
 
 ## Python
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Pull request descriptions
 
 The PR description can introduce the reader . The PR description is a description of the *change* rather than the code. If there's context the reader needs to understand the code, the code itself should provide that context. After the code is merged, it should make sense to people who haven't read the pull request description.
 
+Can omit when trivial.
+
+Include "Fixes XX"
 
 ## Python
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ If there were implementation decisions, include them.
 
 * Aim for fewer than 80 characters
   * This is a soft limit, but it's better to be succinct
+  * In some views (including on Github), exceeding 80 characters screws up the PR link
 * Use imperative mood ("Refactor input handling") rather than descriptive ("Refactors input handling")
 * Use sentence casing.
 * Omit trailing punctuation.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The pull request (PR) title should summarize the change to make it easy for othe
   * This is a soft limit, but it's better to be succinct.
   * In some views (including on Github), exceeding 80 characters screws up the PR link.
 * Use imperative mood ("Refactor input handling") rather than descriptive ("Refactors input handling").
-* Use sentence casing ("Refactor input handling" rather than "Refactor Input Handling").
+* Use sentence casing ("Refactor input handling") rather than titel casing ("Refactor Input Handling").
 * Omit trailing punctuation.
 * Omit prefixes like "(chore)" or "(fix)".
 * Omit Markdown formatting.
@@ -24,11 +24,15 @@ The pull request (PR) title should summarize the change to make it easy for othe
 
 ### Descriptions
 
-The pull request description should introduce the reader to the change and provide them with the context they need to review the change. Write the pull request so that it makes sense to anyone on the team even if you have a particular reviewer in mind who has additional context. Other people might want to read the PR, and you might forget the context in the future if you look back on it.
+The pull request description should introduce the reader to the change and provide them with the context they need to review the change.
+
+Write the pull request description so that it makes sense to anyone on the team, even if you have a particular reviewer in mind who has additional context. Other people might want to read the PR, and you might forget the context in the future if you look back on it.
 
 #### What to include
 
-Link to external resources when appropriate, but the reader should be able to understand everything in the PR description without clicking external links. If you're linking to a bug, summarize the relevant details of the bug. If you're linking to external documentation, quote the relevant section and link back to the original (linking to the specific header if possible).
+The PR description should give a reviewer everything they need to review the PR effectively.
+
+The reviewer should be able to review the PR without clicking external links in the PR description. The description should quote and summarize relevant details from external resources and link to them so that the reviewer can explore further if they choose. If you're linking to a bug, summarize the relevant details of the bug. If you're linking to external documentation, quote the relevant section and link back to the original (linking to the specific header if possible).
 
 If you made design choices in the PR, explain why you chose a particular implementation over other possible candidates.
 
@@ -40,7 +44,7 @@ The PR description is a description of the *change* rather than the code. It sho
 
 If there's context the reader needs to understand the code, the code itself should provide that context either through naming or code comments. After the code is merged, the code needs to make sense to people who haven't read the pull request description.
 
-Example bad description:
+##### Example bad description
 
 >**Move user.js**
 >
@@ -48,7 +52,7 @@ Example bad description:
 
 This is a poor description because it doesn't give the reader any information about the change beyond what they'd see in the diff.
 
-Example good description:
+##### Example good description
 
 >**Move user.js to src/controllers/auth**
 >
@@ -60,7 +64,7 @@ This is a better PR description because it explains the "why" behind the change.
 
 #### Cross-referencing issues
 
-If the PR resolves a bug, include a line after the prose description that says `Fixes #XXX` where `XXX` is the number of the Github issue it resolves. Doing this lets Github auto-close the associated issue when we merge the PR.
+If the PR resolves a bug, include a line after the prose description that says `Fixes #XXX` where `XXX` is the number of the Github issue it resolves. The `Fixes #XXX` syntax tells Github to auto-close the associated issue when we merge the PR.
 
 If the PR is related to an issue but doesn't fix it, add a line that says `Related #XXX` so that Github cross-references the PR from the associated bug.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # style-guides
 
-This page defines TinyPilot's coding conventions for various programming languages.
+This page defines TinyPilot's conventions for various programming languages.
+
+TinyPilot team members and contributors should follow these conventions when contributing to any TinyPilot-owned repository.
 
 ## General
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Sometimes the code review process changes the code and makes the original PR des
 
 Mark the PR as a "draft" when it's not ready to be merged in. You can request a review on a draft PR, but the implication is that you're seeking only preliminary, high-level feedback.
 
-Remove the "draft" state when you feel the code is ready to be merged. Your reviewer will likely have feedback, but removing the "draft" state means that you've made the code as good as you can make it, and you'd be comfortable merging it in if your reviewer has no notes.
+Click the PR's "Ready for Review" button on a draft PR when you feel the code is ready to be merged. Your reviewer will likely have feedback, but removing the "draft" state means that you've made the code as good as you can make it, and you'd be comfortable merging it in if your reviewer has no notes.
 
 ## Python
 

--- a/README.md
+++ b/README.md
@@ -8,25 +8,25 @@ TinyPilot's style guides mostly inherit from other established style guides and 
 
 ## Github pull requests
 
-### Titles
+### Pull request titles
 
 The pull request (PR) title should summarize the change to make it easy for other developers to quickly scan through the change history for the repo or a file/folder.
 
 * Aim for fewer than 80 characters.
   * This is a soft limit, but it's better to be succinct.
   * In some views (including on Github), exceeding 80 characters screws up the PR link.
-* Use imperative mood ("Refactor input handling") rather than descriptive ("Refactors input handling").
-* Use sentence casing ("Refactor input handling") rather than titel casing ("Refactor Input Handling").
+* Use imperative mood ("**Refactor** input handling") rather than descriptive ("**Refactors** input handling").
+* Use sentence casing ("Refactor input handling") rather than title casing ("Refactor Input Handling").
 * Omit trailing punctuation.
 * Omit prefixes like "(chore)" or "(fix)".
-* Omit Markdown formatting.
+* Omit Markdown formatting characters such as backticks.
   * Github renders Markdown in PR titles, but not all git clients do.
 
-### Descriptions
+### Pull request descriptions
 
-The pull request description should introduce the reader to the change and provide them with the context they need to review the change.
+The PR description should introduce the reader to the change and provide them with the context they need to review it.
 
-Write the pull request description so that it makes sense to anyone on the team, even if you have a particular reviewer in mind who has additional context. Other people might want to read the PR, and you might forget the context in the future if you look back on it.
+Write the pull request description so that it makes sense to anyone on the team, even if you have a particular reviewer in mind. Other people might want to read the PR that don't have the reviewer's context, and you yourself will eventually forget the extra context you had when you wrote the code.
 
 #### What to include
 
@@ -36,13 +36,13 @@ The reviewer should be able to review the PR without clicking external links in 
 
 If you made design choices in the PR, explain why you chose a particular implementation over other possible candidates.
 
-For very trivial PRs, the description is optional, but it's usually helpful to include a description.
+For trivial PRs, the description is optional, but it's usually helpful to include a description.
 
 #### Focus on the "why" rather than the "how"
 
-The PR description is a description of the *change* rather than the code. It should answer the question, "Why are we making this change right now?"
+The PR description should focus on the *change* rather than the code. It should answer the question, "Why are we making this change right now?"
 
-If there's context the reader needs to understand the code, the code itself should provide that context either through naming or code comments. After the code is merged, the code needs to make sense to people who haven't read the pull request description.
+If there's context the reader needs to understand the code, the code itself should provide that context either through naming, structure, or code comments. After the code is merged, the code needs to make sense to people who haven't read the pull request description.
 
 ##### Example bad description
 
@@ -60,23 +60,23 @@ This is a poor description because it doesn't give the reader any information ab
 >
 >We did a lot of restructing as part of the 4.2.x release, so now all of user.js’s clients live in `src/controllers/auth`, so this change moves `user.js` closer to the majority of its clients.
 
-This is a better PR description because it explains the "why" behind the change. The reader has context to understand why this change is happening.
+This is a better PR description because it explains the "why" behind the change.
 
 #### Cross-referencing issues
 
-If the PR resolves a bug, include a line after the prose description that says `Fixes #XXX` where `XXX` is the number of the Github issue it resolves. The `Fixes #XXX` syntax tells Github to auto-close the associated issue when we merge the PR.
+If the PR resolves a bug, include a line after the prose description that says `Fixes #XXX` where `XXX` is the number of the Github issue it resolves. The `Fixes #XXX` has special meaning within Github, as merging the PR will auto-close the associated issue.
 
 If the PR is related to an issue but doesn't fix it, add a line that says `Related #XXX` so that Github cross-references the PR from the associated bug.
 
-#### Revise to match design changes
+#### Revise the description to match the implementation
 
-Sometimes the code review process causes changes in the code that make your original PR description obsolete. Remember to update your PR description to match the state of your code.
+Sometimes the code review process changes the code and makes the original PR description obsolete. Remember to update your PR description to match the state of your code.
 
 ### Drafts vs. non-drafts
 
 Mark the PR as a "draft" when it's not ready to be merged in. You can request a review on a draft PR, but the implication is that you're seeking only preliminary, high-level feedback.
 
-Remove the "draft" state when you feel the code is ready to be merged. Your reviewer will likely have feedback, but removing the "draft" state means that you've made the code as good as you can make it, and you'd be content merging it in if your reviewer has no notes.
+Remove the "draft" state when you feel the code is ready to be merged. Your reviewer will likely have feedback, but removing the "draft" state means that you've made the code as good as you can make it, and you'd be comfortable merging it in if your reviewer has no notes.
 
 ## Python
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ If the PR is related to an issue but doesn't fix it, add a line that says `Relat
 
 Sometimes the code review process causes changes in the code that make your original PR description obsolete. Remember to update your PR description to match the state of your code.
 
+### Drafts vs. non-drafts
+
+Mark the PR as a "draft" when it's not ready to be merged in. You can request a review on a draft PR, but the implication is that you're seeking only preliminary, high-level feedback.
+
+Remove the "draft" state when you feel the code is ready to be merged. Your reviewer will likely have feedback, but removing the "draft" state means that you've made the code as good as you can make it, and you'd be content merging it in if your reviewer has no notes.
+
 ## Python
 
 - Base Guide: [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The pull request (PR) title should summarize the change to make it easy for othe
 * Omit prefixes like "(chore)" or "(fix)".
 * Omit Markdown formatting characters such as backticks.
   * Github renders Markdown in PR titles, but not all git clients do.
+  * Use Markdown in PR descriptions because it has better cost:benefit ratio there. In the description, Markdown allows links and embedded media, whereas the most we'd want in the title is backticked titles, which isn't so useful when rendered and adds clutter for git clients that don't render Markdown.
 
 ### Pull request descriptions
 
@@ -34,7 +35,9 @@ The PR description should give a reviewer everything they need to review the PR 
 
 The reviewer should be able to review the PR without clicking external links in the PR description. The description should quote and summarize relevant details from external resources and link to them so that the reviewer can explore further if they choose. If you're linking to a bug, summarize the relevant details of the bug. If you're linking to external documentation, quote the relevant section and link back to the original (linking to the specific header if possible).
 
-If you made design choices in the PR, explain why you chose a particular implementation over other possible candidates.
+If you're changing the UI, considering including a screenshot or short video demo. Visuals should supplement a clear written description of the changes rather than substituting it.
+
+If you considered other implementation options, explain why you chose a particular implementation over other possible candidates.
 
 For trivial PRs, the description is optional, but it's usually helpful to include a description.
 
@@ -70,7 +73,9 @@ If the PR is related to an issue but doesn't fix it, add a line that says `Relat
 
 #### Revise the description to match the implementation
 
-Sometimes the code review process changes the code and makes the original PR description obsolete. Remember to update your PR description to match the state of your code.
+When we squash and merge the commit, the PR title and description become the commit message. The commit message is a permanent part of the source history, so we want it to be accurate when we merge the PR.
+
+If changes during the code review process make the original PR description obsolete, remember to update the PR description to match the code.
 
 ### Drafts vs. non-drafts
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,32 @@ This page defines TinyPilot's coding conventions for various programming languag
 
 TinyPilot's style guides mostly inherit from other established style guides and make changes where we've felt the parent guide lacks specificity or makes a choice that's poorly suited for TinyPilot's work.
 
+## Pull requests
+
+Pull requests (PRs)
+
+Focus on the why rather than the how.
+
+Should introduce the reader to
+
+If there were implementation decisions, include them.
+
+### Titles
+
+* Aim for fewer than 80 characters
+  * This is a soft limit, but it's better to be succinct
+* Use imperative mood ("Refactor input handling") rather than descriptive ("Refactors input handling")
+* Use sentence casing.
+* Omit trailing punctuation.
+* Omit prefixes like "(chore)" or "(fix)".
+
+### Descriptions
+
+Pull request descriptions
+
+The PR description can introduce the reader . The PR description is a description of the *change* rather than the code. If there's context the reader needs to understand the code, the code itself should provide that context. After the code is merged, it should make sense to people who haven't read the pull request description.
+
+
 ## Python
 
 - Base Guide: [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)


### PR DESCRIPTION
I've noticed as @amfarrell has onboarded that it's difficult for new teammates to understand our conventions around Github pull requests.

This change defines our PR conventions so that we can all write them consistently and deliberately.

Fixes #6

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/style-guides/7"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>