### PR TITLE
Update standard comment for set -x

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All bash scripts should default to these options unless there's a strong need to
 # Exit on first failure.
 set -e
 
-# Echo commands to stdout.
+# Echo commands before executing them, by default to stderr.
 set -x
 
 # Exit on unset variable.


### PR DESCRIPTION
We recently discovered that set -x actually prints to stderr not stdout, so we should update our standard comment in bash scripts

Related: https://github.com/tiny-pilot/tinypilot/pull/1331
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/style-guides/8"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>