### PR TITLE
Update convention for shell variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,16 +128,31 @@ TIMEOUT_SECONDS=5
 
 ### Variable names
 
-Variable names should be all uppercase.
+Constant variables and exported environment variables should be all uppercase.
 
 ```bash
-WELCOME_MESSAGE="Hello, world!"
+readonly WELCOME_MESSAGE='Hello, world!'
 ```
 
 ```bash
-for URL in "${URLS[@]}"; do
-  wget "${URL}"
+WELCOME_MESSAGE="$(echo 'Hello, World!')"
+readonly WELCOME_MESSAGE
+export WELCOME_MESSAGE
+```
+
+Non-constant variables, such as the ones in loops or for local function variables, should be all lowercase.
+
+```bash
+for url in "${URLS[@]}"; do
+  wget "${url}"
 done
+```
+
+```bash
+print() {
+  local message="$1"
+  echo "${message}"
+}
 ```
 
 ### Command-line flags

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ TIMEOUT_SECONDS=5
 
 ### Variable names
 
-Constant variables and exported environment variables should be all uppercase.
+Constant variables and exported environment variables should be uppercase.
 
 ```bash
 readonly WELCOME_MESSAGE='Hello, world!'

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Non-constant variables, such as the ones in loops, should be lowercase.
 
 ```bash
 for value in 1 2 3; do
-  echo "Hello "${value}" times"
+  echo "Hello ${value} times"
 done
 ```
 

--- a/README.md
+++ b/README.md
@@ -140,19 +140,19 @@ readonly WELCOME_MESSAGE
 export WELCOME_MESSAGE
 ```
 
-Non-constant variables, such as the ones in loops or for local function variables, should be all lowercase.
+```bash
+print() {
+  local -r MESSAGE=$1
+  echo "${MESSAGE}"
+}
+```
+
+Non-constant variables, such as the ones in loops, should be lowercase.
 
 ```bash
 for value in 1 2 3; do
   echo "Hello "${value}" times"
 done
-```
-
-```bash
-print() {
-  local message="$1"
-  echo "${message}"
-}
 ```
 
 ### Command-line flags

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ export WELCOME_MESSAGE
 Non-constant variables, such as the ones in loops or for local function variables, should be all lowercase.
 
 ```bash
-for url in "${URLS[@]}"; do
-  wget "${url}"
+for value in 1 2 3; do
+  echo "Hello "${value}" times"
 done
 ```
 


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/style-guides/issues/5

This PR updates our convention for shell variable names to explicitly mention the case of non-constant variables.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/style-guides/11"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>