### PR TITLE
Add our here-document convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ for value in 1 2 3; do
 done
 ```
 
+### Here documents
+
 Here-documents should use `EOF` as the delimiting identifier label.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ for value in 1 2 3; do
 done
 ```
 
+Here-documents should use `EOF` as the delimiting identifier label.
+
+```bash
+sudo tee --append /etc/janus/janus.jcfg << EOF
+nat: {
+  stun_server = "${STUN_SERVER}"
+  stun_port = ${STUN_PORT}
+}
+EOF
+```
+
 ### Using command-line flags
 
 If a bash script calls another application that accepts command-line flags, use long flag names where available.


### PR DESCRIPTION
This adds our here-document convention to the style guide. The key point is simply that we use `EOF` rather than `END` as the delimiting identifier label.

We don’t seem to have a consistent rule for `<<EOF` vs `<< EOF`, but we do use spacing to improve readability in many places so I’ve opted to not explicitly define a convention while still using `<< EOF` in the example.

I’ve not mentioned disabling parsing (i.e. using `<< ’EOF’`) as it’s a standard behaviour. I’ve also not mentioned using `<< END` if `<< EOF` would clash with the here-document contents, but I’m open to changing that.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/style-guides/14"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>