### PR TITLE
Adjust bash style guide to define constants close to first use

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Comments begin with a capital letter and end with trailing punctuation.
 TIMEOUT_SECONDS=5
 ```
 
-### Casing of variable names
+### Variable name casing
 
 Constant variables and exported environment variables should be uppercase.
 


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/style-guides/issues/12.

- I renamed the “Variable names” heading to make it more distinct from the new section. (Can you say “casing” in English?)
- I thought it was worthwhile to capture the context *why* we decided to do this, so that it’s easier to understand our motivation in the future.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/style-guides/15"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>