### PR TITLE
Fix guidance on bash flag-parsing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ EOF
 
 TARGET_FILE=''
 FORCE='false'
-while [[ "$#" -gt 0 ]]; do
+# TODO: Change the 2 to the minimum number of valid arguments the script
+# expects.
+while [[ "$#" -gt 2 ]]; do
   case "$1" in
     --help)
       print_help


### PR DESCRIPTION
From https://github.com/tiny-pilot/gatekeeper/pull/204, we realized the boilerplate has a bug in that it gives unclear an error message if the script receives no command line arguments.

This change fixes the bug and gives clearer guidance on how we should customize it when copying the boilerplate.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/style-guides/17"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>